### PR TITLE
[nuget-archive] Add index integrity attribute to nuget_archive

### DIFF
--- a/dotnet/private/rules/nuget/nuget_archive.bzl
+++ b/dotnet/private/rules/nuget/nuget_archive.bzl
@@ -262,7 +262,7 @@ def _process_key_and_file(groups, key, file):
 
     return
 
-def _get_package_urls(rctx, sources, auth, package_id, package_version):
+def _get_package_urls(rctx, sources, auth, index_integrity, package_id, package_version):
     base_addresses = {}
     package_urls = []
 
@@ -274,7 +274,7 @@ def _get_package_urls(rctx, sources, auth, package_id, package_version):
         # and the url schema for the package contents will be:
         # {base_address}/{lower_id}/{lower_version}/{lower_id}.{lower_version}.nupkg
         if source.endswith("index.json"):
-            rctx.download(source, auth = auth, output = "index.json")
+            rctx.download(source, auth = auth, output = "index.json", integrity = index_integrity)
             index = json.decode(rctx.read("index.json"))
             rctx.delete("index.json")
             for resource in index["resources"]:
@@ -317,7 +317,7 @@ def _nuget_archive_impl(ctx):
     # First get the auth dict for the package sources since the sources can be different than the
     # package base url when using NuGet V3 feeds.
     auth = _get_auth_dict(ctx, ctx.attr.netrc, ctx.attr.sources)
-    urls = _get_package_urls(ctx, ctx.attr.sources, auth, ctx.attr.id, ctx.attr.version)
+    urls = _get_package_urls(ctx, ctx.attr.sources, auth, ctx.attr.index_integrity, ctx.attr.id, ctx.attr.version)
 
     # Then get the auth dict for the package base urls
     auth = _get_auth_dict(ctx, ctx.attr.netrc, urls)
@@ -467,6 +467,7 @@ nuget_archive = repository_rule(
         "id": attr.string(),
         "version": attr.string(),
         "sha512": attr.string(),
+        "index_integrity": attr.string(),
     },
 )
 


### PR DESCRIPTION
Allow explicit integrity for index.json in the nuget_archive repo rule.
Solve the following issue: https://github.com/bazelbuild/rules_dotnet/issues/431

I previously created https://github.com/bazelbuild/rules_dotnet/pull/432, but in that PR I committed with a different e-mail for which I did not sign a CLA.