### PR TITLE
Expose source-files and project structure

### DIFF
--- a/dotnet/private/providers.bzl
+++ b/dotnet/private/providers.bzl
@@ -89,3 +89,24 @@ DotnetApphostPackInfo = provider(
         "apphost": "File: The apphost file",
     },
 )
+
+DotnetCompileInfo = provider(
+    doc = "Information about how a .Net target is to be compiled",
+    fields = {
+        "label": "Label: The label of the target",
+        "srcs": "list[File]: sources to be compiled",
+        "deps": "list[DotnetCompileDepVariantInfo]: The direct dependencies of the target",
+        "transitive_deps": "depset[DotnetCompileDepVariantInfo]: The transitive dependencies of the target",
+    },
+)
+
+DotnetCompileDepVariantInfo = provider(
+    doc = "A wrapper provider for a compilation dependency. The dependency can be a project " +
+          "dependency, in which case the `dotnet_compile_info` will be populated" +
+          "or a NuGet dependency, in which case `dotnet_assembly_compile_info` will be populated.",
+    fields = {
+        "label": "Label: The label of the dependency",
+        "dotnet_compile_info": "DotnetCompileInfo: The DotnetCompileInfo of a dependency",
+        "dotnet_assembly_compile_info": "DotnetAssemblyCompileInfo: The NuGet info of a dependency",
+    },
+)

--- a/dotnet/private/rules/common/binary.bzl
+++ b/dotnet/private/rules/common/binary.bzl
@@ -13,6 +13,10 @@ load(
     "to_rlocation_path",
 )
 load("//dotnet/private:providers.bzl", "DotnetApphostPackInfo", "DotnetBinaryInfo", "DotnetRuntimePackInfo")
+load(
+    "//dotnet/private/rules/common:compile_info.bzl",
+    "gather_compile_info"
+)
 
 def _create_launcher(ctx, runfiles, executable):
     runtime = ctx.toolchains["//dotnet:toolchain_type"].runtime
@@ -136,4 +140,6 @@ def build_binary(ctx, compile_action):
         runtime_pack_info = ctx.attr._runtime_pack[0][DotnetRuntimePackInfo],
     )
 
-    return [default_info, dotnet_binary_info, compile_provider, runtime_provider]
+    compile_info_provider = gather_compile_info(ctx)
+
+    return [default_info, dotnet_binary_info, compile_provider, runtime_provider, compile_info_provider]

--- a/dotnet/private/rules/common/compile_info.bzl
+++ b/dotnet/private/rules/common/compile_info.bzl
@@ -1,0 +1,42 @@
+"Utility function for collecting compilation information from contexts"
+
+load("//dotnet/private:providers.bzl", "NuGetInfo", "DotnetCompileInfo", "DotnetCompileDepVariantInfo", "DotnetAssemblyCompileInfo")
+
+
+def gather_compile_info(ctx):
+    """Collects compilation information from a context
+
+    Args:
+        ctx: Bazel build ctx.
+    Returns:
+        A collection of the source-files, dependencies and transitive dependencies
+    """
+    direct_deps = []
+    transitive_deps = []
+
+    for dep in ctx.attr.deps:
+        if DotnetCompileInfo in dep:
+            variant = DotnetCompileDepVariantInfo(
+                label = dep.label,
+                dotnet_compile_info = dep[DotnetCompileInfo],
+                dotnet_assembly_compile_info = None,
+            )
+
+            direct_deps.append(variant)
+            transitive_deps.append(depset(dep[DotnetCompileInfo].deps, transitive = [ dep[DotnetCompileInfo].transitive_deps ]))
+
+        if NuGetInfo in dep and DotnetAssemblyCompileInfo in dep:
+            variant = DotnetCompileDepVariantInfo(
+                label = dep.label,
+                dotnet_compile_info = None,
+                dotnet_assembly_compile_info = dep[DotnetAssemblyCompileInfo],
+            )
+
+            direct_deps.append(variant)
+
+    return DotnetCompileInfo(
+        label = ctx.label,
+        srcs = ctx.files.srcs,
+        deps = direct_deps,
+        transitive_deps = depset([], transitive = transitive_deps),
+    )

--- a/dotnet/private/rules/common/library.bzl
+++ b/dotnet/private/rules/common/library.bzl
@@ -2,6 +2,10 @@
 
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("//dotnet/private:common.bzl", "collect_transitive_runfiles")
+load(
+    "//dotnet/private/rules/common:compile_info.bzl",
+    "gather_compile_info"
+)
 
 def build_library(ctx, compile_action):
     """Builds a .Net library from a compilation action
@@ -21,9 +25,12 @@ def build_library(ctx, compile_action):
 
     (compile_provider, runtime_provider) = compile_action(ctx, tfm)
 
+    compile_info_provider = gather_compile_info(ctx)
+
     return [
         compile_provider,
         runtime_provider,
+        compile_info_provider,
         DefaultInfo(
             files = depset(runtime_provider.libs + runtime_provider.xml_docs),
             default_runfiles = collect_transitive_runfiles(

--- a/dotnet/private/rules/fsharp/actions/fsharp_assembly.bzl
+++ b/dotnet/private/rules/fsharp/actions/fsharp_assembly.bzl
@@ -118,7 +118,7 @@ def AssemblyAction(
         keyfile: Specifies a strong name key file of the assembly.
         langversion: Specify language version: Default, ISO-1, ISO-2, 3, 4, 5, 6, 7, 7.1, 7.2, 7.3, or Latest
         resources: The list of resouces to be embedded in the assembly.
-        srcs: The list of source (.cs) files that are processed to create the assembly.
+        srcs: The list of source (.fs) files that are processed to create the assembly.
         data: List of files that are a direct runtime dependency
         appsetting_files: List of appsettings files to include in the output.
         compile_data: List of files that are a direct compile time dependency


### PR DESCRIPTION
In order to build Bazel rules for [Fable](https://github.com/fable-compiler/Fable), we need access to the F# source-files and target dependency graph. This information can be used to generate `fsproj` files that the Fable CLI tool can understand. 

This PR exposes these things, but in a generic way, so that it can be used for multiple purposes.

I was able to build a proof-of-concept set of rules for Fable on top of this. However, before going further I would like feedback on these changes, since I hope to eventually have them merged into `rules_dotnet`. 

Thanks!

Related: https://github.com/bazel-contrib/rules_dotnet/issues/315