### PR TITLE
Teach gitattributes/linguist to highlight bzlmod files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 docs/*.md linguist-generated=true
+# Until linguist catches up https://github.com/github-linguist/linguist/blob/main/lib/linguist/languages.yml#L6998-L7019
+*.bzlmod linguist-language=starlark


### PR DESCRIPTION
(Upstream PR to make this out-of-the-box: https://github.com/github-linguist/linguist/pull/7121)