### PR TITLE
Pass dependencies of analyzers as analyzer DLLs

### DIFF
--- a/dotnet/private/rules/csharp/actions/csharp_assembly.bzl
+++ b/dotnet/private/rules/csharp/actions/csharp_assembly.bzl
@@ -51,6 +51,24 @@ def _write_internals_visible_to_csharp(actions, label_name, dll_name, others):
 
     return output
 
+def _collect_analyzer_dependencies(deps):
+    """Collect the runtime libraries of this analyzer. These will be passed to the compiler.
+
+    Args:
+        deps: The list of dependencies of the analyzer.
+
+    Returns:
+        The list of analyzer dependencies.
+    """
+
+    dlls = []
+    for dep in deps:
+        runtime_info = dep[DotnetAssemblyRuntimeInfo]
+
+        # FIXME: Should this respect `not strict_deps`?
+        dlls.extend(runtime_info.libs)
+    return dlls
+
 # buildifier: disable=unnamed-macro
 def AssemblyAction(
         actions,
@@ -157,6 +175,12 @@ def AssemblyAction(
         exports,
         strict_deps,
     )
+
+    if (is_analyzer or is_language_specific_analyzer) and target_framework != "netstandard2.0":
+        fail("Analyzers must have `target_frameworks = [\"netstandard2.0\"]`.")
+
+    # TODO: Ensure that all the analyzer DLLs also target netstandard2.0.
+    analyzer_dlls = _collect_analyzer_dependencies(deps) if (is_analyzer or is_language_specific_analyzer) else []
 
     defines = framework_preprocessor_symbols(target_framework) + defines
 
@@ -303,8 +327,8 @@ def AssemblyAction(
         project_sdk = project_sdk,
         refs = [out_ref] if not is_analyzer else [],
         irefs = [out_iref] if out_iref else [out_ref],
-        analyzers = [] if (not is_analyzer) or is_language_specific_analyzer else [out_dll],
-        analyzers_csharp = [out_dll] if is_language_specific_analyzer else [],
+        analyzers = [] if (not is_analyzer) or is_language_specific_analyzer else ([out_dll] + analyzer_dlls),
+        analyzers_csharp = ([out_dll] + analyzer_dlls) if is_language_specific_analyzer else [],
         analyzers_fsharp = [],
         analyzers_vb = [],
         internals_visible_to = internals_visible_to or [],
@@ -319,7 +343,7 @@ def AssemblyAction(
     ), DotnetAssemblyRuntimeInfo(
         name = assembly_name,
         version = "1.0.0",  #TODO: Maybe make this configurable?
-        libs = [out_dll] if not is_analyzer else [],
+        libs = [out_dll] if not (is_analyzer or is_language_specific_analyzer) else [],
         pdbs = [out_pdb] if out_pdb else [],
         xml_docs = [out_xml] if out_xml else [],
         data = data,

--- a/dotnet/private/tests/analyzer_dependencies/Analyzer.cs
+++ b/dotnet/private/tests/analyzer_dependencies/Analyzer.cs
@@ -1,0 +1,5 @@
+namespace Analyzer;
+
+// NOTE: Doesn't actually do anything. Maybe the test could be enhanced by making this
+//       an actual analyzer.
+public static class Analyzer { }

--- a/dotnet/private/tests/analyzer_dependencies/BUILD.bazel
+++ b/dotnet/private/tests/analyzer_dependencies/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":analyzer_dependencies.bzl", "test_analyzer_dependencies")
+
+test_analyzer_dependencies()

--- a/dotnet/private/tests/analyzer_dependencies/Core.cs
+++ b/dotnet/private/tests/analyzer_dependencies/Core.cs
@@ -1,0 +1,9 @@
+namespace Core;
+
+public class MyUtility
+{
+    public void Frobnicate()
+    {
+        System.Console.WriteLine("Frobnicating...");
+    }
+}

--- a/dotnet/private/tests/analyzer_dependencies/User.cs
+++ b/dotnet/private/tests/analyzer_dependencies/User.cs
@@ -1,0 +1,13 @@
+using Core;
+
+namespace User;
+
+public static class Program
+{
+    public static void Main()
+    {
+        // Ensure that the Core library was linked in as a runtime dependency.
+        var util = new MyUtility();
+        util.Frobnicate();
+    }
+}

--- a/dotnet/private/tests/analyzer_dependencies/analyzer_dependencies.bzl
+++ b/dotnet/private/tests/analyzer_dependencies/analyzer_dependencies.bzl
@@ -1,0 +1,107 @@
+"Tests for ensuring analyzers' dependencies are correctly passed in."
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest")
+load("//dotnet:defs.bzl", "csharp_library")
+load(
+    "//dotnet/private:providers.bzl",
+    "DotnetAssemblyCompileInfo",
+    "DotnetAssemblyRuntimeInfo",
+)
+
+def _force_netstandard20_transition_impl(_settings, _attr):
+    return {"//dotnet:target_framework": "netstandard2.0"}
+
+force_netstandard20_transition = transition(
+    implementation = _force_netstandard20_transition_impl,
+    inputs = [],
+    outputs = ["//dotnet:target_framework"],
+)
+
+def _has_analyzer_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    compile_info = target_under_test[DotnetAssemblyCompileInfo]
+    if ctx.attr.target_language == "any":
+        actual_analyzer_libs = compile_info.analyzers + compile_info.transitive_analyzers.to_list()
+    elif ctx.attr.target_language == "csharp":
+        actual_analyzer_libs = compile_info.csharp_analyzers + compile_info.transitive_csharp_analyzers.to_list()
+    elif ctx.attr.target_language == "fsharp":
+        actual_analyzer_libs = compile_info.fsharp_analyzers + compile_info.transitive_fsharp_analyzers.to_list()
+    elif ctx.attr.target_language == "vb":
+        actual_analyzer_libs = compile_info.vb_analyzers + compile_info.transitive_vb_analyzers.to_list()
+    else:
+        fail("Unknown target language: {}".format(ctx.attr.target_language))
+
+    for expected_analyzer in ctx.attr.analyzers:
+        expected_compile_info = expected_analyzer[DotnetAssemblyCompileInfo]
+        expected_runtime_info = expected_analyzer[DotnetAssemblyRuntimeInfo]
+        if not expected_runtime_info.libs:
+            # This assembly is an analyzer itself.
+            expected_libs = expected_compile_info.analyzers
+        else:
+            # This assembly is not an analyzer, but its runtime libraries will be
+            # used by analyzers.
+            expected_libs = expected_runtime_info.libs
+
+        for expected_lib in expected_libs:
+            if expected_lib not in actual_analyzer_libs:
+                fail(
+                    "Expected analyzer library {} not found in: {}".format(
+                        expected_lib,
+                        actual_analyzer_libs,
+                    ),
+                )
+
+    return analysistest.end(env)
+
+has_analyzer_test = analysistest.make(
+    _has_analyzer_test_impl,
+    doc = "Tests whether the given target has an analyzer dependency.",
+    attrs = {
+        "analyzers": attr.label_list(
+            doc = "The list of analyzer dependencies to check for.",
+            mandatory = True,
+            providers = [DotnetAssemblyCompileInfo, DotnetAssemblyRuntimeInfo],
+            cfg = force_netstandard20_transition,
+        ),
+        "target_language": attr.string(
+            doc = "The target language to check for analyzers. Can be one of 'any', 'csharp', 'fsharp', or 'vb'.",
+            mandatory = True,
+            values = ["any", "csharp", "fsharp", "vb"],
+        ),
+    },
+)
+
+# buildifier: disable=function-docstring
+# buildifier: disable=unnamed-macro
+def test_analyzer_dependencies():
+    csharp_library(
+        name = "core_lib",
+        srcs = ["Core.cs"],
+        target_frameworks = ["net9.0", "netstandard2.0"],
+        langversion = "latest",
+    )
+
+    csharp_library(
+        name = "analyzer_lib",
+        is_analyzer = True,
+        srcs = ["Analyzer.cs"],
+        deps = [":core_lib"],
+        target_frameworks = ["netstandard2.0"],
+        langversion = "latest",
+    )
+
+    csharp_library(
+        name = "user_lib",
+        srcs = ["User.cs"],
+        deps = [":core_lib", ":analyzer_lib"],
+        target_frameworks = ["net9.0"],
+    )
+
+    has_analyzer_test(
+        name = "analyzer_dependency_was_passed_in",
+        target_under_test = ":user_lib",
+        analyzers = [":core_lib", ":analyzer_lib"],
+        target_language = "any",
+    )


### PR DESCRIPTION
If an analyzer library has dependencies, then those should be passed as analyzers to the compiler. Note that this has to happen during assembly creation and not when another library uses this analyzer, because we need to use the actual runtime libraries present in `DotnetAssemblyRuntimeInfo` as analyzers (not the refs, which is all that's present in `DotnetAssemblyCompileInfo`).

In this change, we only do one level of discovery. This means if a transitive dependency of another library is required in an analyzer library, those must also be passed into deps. This is similar to strict_deps, but is stricter because unlike a regular dependency which only needs its reference DLL to be present at compile time (and reference DLLs don't require their own dependencies), we need the full transitive dependency chain to be present at compile time for an analyzer.

Fixes #471.

TODO:
- [x] Test for ensuring that analyzer deps are passed in as analyzers