### PR TITLE
Implement NET*_OR_GREATER preprocessor defines

### DIFF
--- a/dotnet/private/common.bzl
+++ b/dotnet/private/common.bzl
@@ -507,16 +507,24 @@ def framework_preprocessor_symbols(tfm):
     Returns:
         A list of preprocessor symbols.
     """
-    # TODO: All built in preprocessor directives: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives
 
-    specific = tfm.upper().replace(".", "_")
+    defines = [tfm.upper().replace(".", "_")] + [
+        # net8.0 -> NET8_0_OR_GREATER
+        # net461 -> NET461_OR_GREATER
+        framework.upper().replace(".", "_") + "_OR_GREATER"
+        for framework in sets.to_list(TRANSITIVE_FRAMEWORK_COMPATIBILITY[tfm])
+    ]
 
     if tfm.startswith("netstandard"):
-        return ["NETSTANDARD", specific]
+        defines.append("NETSTANDARD")
     elif tfm.startswith("netcoreapp"):
-        return ["NETCOREAPP", specific]
-    else:
-        return ["NETFRAMEWORK", specific]
+        defines.append("NETCOREAPP")
+    elif tfm.startswith("net4"):
+        defines.append("NETFRAMEWORK")
+    elif tfm.startswith("net"):
+        defines.append("NET")
+
+    return defines
 
 # For deps.json spec see: https://github.com/dotnet/sdk/blob/main/documentation/specs/runtime-configuration-file.md
 def generate_depsjson(

--- a/dotnet/private/tests/framework_preprocessor_defines/BUILD.bazel
+++ b/dotnet/private/tests/framework_preprocessor_defines/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":framework_preprocessor_defines.bzl", "test_framework_preprocessor_defines")
+
+test_framework_preprocessor_defines()

--- a/dotnet/private/tests/framework_preprocessor_defines/Hello.cs
+++ b/dotnet/private/tests/framework_preprocessor_defines/Hello.cs
@@ -1,0 +1,7 @@
+public static class Program
+{
+    public static void Main()
+    {
+        System.Console.WriteLine("Well hello friends!");
+    }
+}

--- a/dotnet/private/tests/framework_preprocessor_defines/framework_preprocessor_defines.bzl
+++ b/dotnet/private/tests/framework_preprocessor_defines/framework_preprocessor_defines.bzl
@@ -1,0 +1,89 @@
+"Tests for ensuring that NET*_OR_GREATER defines are properly set when targeting a given TFM."
+
+load("//dotnet:defs.bzl", "csharp_library")
+load("//dotnet/private/tests:utils.bzl", "action_args_test")
+
+# buildifier: disable=unnamed-macro
+# buildifier: disable=function-docstring
+def test_framework_preprocessor_defines():
+    # TODO: Also test .NET Framework. Currently blocked by https://github.com/bazel-contrib/rules_dotnet/issues/477
+
+    csharp_library(
+        name = "lib_netstd",
+        srcs = ["Hello.cs"],
+        target_frameworks = ["netstandard2.0"],
+    )
+
+    csharp_library(
+        name = "lib_netcore",
+        srcs = ["Hello.cs"],
+        target_frameworks = ["net8.0"],
+    )
+
+    csharp_library(
+        name = "lib_netcoreapp",
+        srcs = ["Hello.cs"],
+        target_frameworks = ["netcoreapp3.1"],
+    )
+
+    action_args_test(
+        name = "test_netstd",
+        target_under_test = ":lib_netstd",
+        action_mnemonic = "CSharpCompile",
+        expected_partial_args = [
+            "/d:NETSTANDARD",
+            "/d:NETSTANDARD2_0",
+            "/d:NETSTANDARD2_0_OR_GREATER",
+            "/d:NETSTANDARD1_6_OR_GREATER",
+        ],
+        expected_nonexistent_partial_args = [
+            "/d:NET",
+            "/d:NETCOREAPP",
+            "/d:NETFRAMEWORK",
+            "/d:NET5_0_OR_GREATER",
+            "/d:NETCOREAPP3_1_OR_GREATER",
+            "/d:NETSTANDARD2_1_OR_GREATER",
+            "/d:NET462_OR_GREATER",
+        ],
+    )
+
+    action_args_test(
+        name = "test_netcore",
+        target_under_test = ":lib_netcore",
+        action_mnemonic = "CSharpCompile",
+        expected_partial_args = [
+            "/d:NET",
+            "/d:NET8_0",
+            "/d:NET8_0_OR_GREATER",
+            "/d:NET6_0_OR_GREATER",
+            "/d:NETSTANDARD2_1_OR_GREATER",
+        ],
+        expected_nonexistent_partial_args = [
+            "/d:NETSTANDARD",
+            "/d:NETCOREAPP",
+            "/d:NETFRAMEWORK",
+            "/d:NET9_0_OR_GREATER",
+            "/d:NET472_OR_GREATER",
+        ],
+    )
+
+    action_args_test(
+        name = "test_netcoreapp",
+        target_under_test = ":lib_netcoreapp",
+        action_mnemonic = "CSharpCompile",
+        expected_partial_args = [
+            "/d:NETCOREAPP",
+            "/d:NETCOREAPP3_1",
+            "/d:NETCOREAPP3_1_OR_GREATER",
+            "/d:NETCOREAPP3_0_OR_GREATER",
+            "/d:NETCOREAPP2_1_OR_GREATER",
+        ],
+        expected_nonexistent_partial_args = [
+            "/d:NET",
+            "/d:NETFRAMEWORK",
+            "/d:NETSTANDARD",
+            "/d:NETCOREAPP5_0_OR_GREATER",
+            "/d:NETCOREAPP6_0_OR_GREATER",
+            "/d:NET472_OR_GREATER",
+        ],
+    )

--- a/dotnet/private/tests/utils.bzl
+++ b/dotnet/private/tests/utils.bzl
@@ -8,6 +8,7 @@ load("//dotnet/private:providers.bzl", "DotnetBinaryInfo")
 ACTION_ARGS_TEST_ARGS = {
     "action_mnemonic": attr.string(),
     "expected_partial_args": attr.string_list(),
+    "expected_nonexistent_partial_args": attr.string_list(),
 }
 
 # We also expose the implementation so that it can be used for testing
@@ -38,6 +39,11 @@ def action_args_test_impl(ctx):
 
         if found_arg == None:
             fail("No match for arg: {}".format(expected_arg))
+
+    for unexpected_arg in ctx.attr.expected_nonexistent_partial_args:
+        for actual_arg in action_under_test.argv:
+            if actual_arg == unexpected_arg:
+                fail("Expected arg not to be present: {}".format(unexpected_arg))
 
     return analysistest.end(env)
 


### PR DESCRIPTION
We recursively go through FRAMEWORK_COMPATIBILITY to obtain all of the TFMs we are compatible with and expose them as defines.

.NET Core and .NET Standard flags have been tested. .NET Framework can't be tested because of #477.