### PR TITLE
Slim down runfiles in publish_binary

### DIFF
--- a/dotnet/private/rules/publish_binary/publish_binary.bzl
+++ b/dotnet/private/rules/publish_binary/publish_binary.bzl
@@ -205,7 +205,7 @@ def _publish_binary_impl(ctx):
         DefaultInfo(
             executable = apphost_shim,
             files = depset([apphost_shim, main_dll, runtimeconfig, depsjson] + outputs),
-            runfiles = ctx.runfiles(files = [apphost_shim, main_dll, runtimeconfig, depsjson] + outputs + runfiles),
+            runfiles = ctx.runfiles(files = runfiles),
         ),
     ]
 


### PR DESCRIPTION
## Why?
Because we only need the user provided runfiles to be in the actual runfiles object. The rest of the files are copied to the correct location in the output directory.