### PR TITLE
Fix runtime/targeting pack conflicts when publishing self-contained

### DIFF
--- a/.devcontainer/features/bazel/install.sh
+++ b/.devcontainer/features/bazel/install.sh
@@ -9,28 +9,33 @@ else
 fi
 
 # Install bazelisk
-curl -o /usr/local/bin/bazelisk-linux-$TARGETARCH -fsSL https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-$TARGETARCH \
+curl -o /usr/local/bin/bazelisk-linux-$TARGETARCH -fsSL https://github.com/bazelbuild/bazelisk/releases/download/v1.26.0/bazelisk-linux-$TARGETARCH \
   && mv /usr/local/bin/bazelisk-linux-$TARGETARCH /usr/local/bin/bazelisk \
   && chmod +x /usr/local/bin/bazelisk \
   && ln -s /usr/local/bin/bazelisk /usr/local/bin/bazel
 
 # Install bazel-watcher
-curl -o /usr/local/bin/ibazel_linux_$TARGETARCH -fsSL https://github.com/bazelbuild/bazel-watcher/releases/download/v0.24.0/ibazel_linux_$TARGETARCH \
+curl -o /usr/local/bin/ibazel_linux_$TARGETARCH -fsSL https://github.com/bazelbuild/bazel-watcher/releases/download/v0.26.1/ibazel_linux_$TARGETARCH \
   && mv /usr/local/bin/ibazel_linux_$TARGETARCH /usr/local/bin/ibazel \
   && chmod +x /usr/local/bin/ibazel
 
 # Install buildifier
-curl -o /usr/local/bin/buildifier-linux-$TARGETARCH -fsSL https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildifier-linux-$TARGETARCH \
+curl -o /usr/local/bin/buildifier-linux-$TARGETARCH -fsSL https://github.com/bazelbuild/buildtools/releases/download/v8.2.0/buildifier-linux-$TARGETARCH \
   && mv /usr/local/bin/buildifier-linux-$TARGETARCH /usr/local/bin/buildifier \
   && chmod +x /usr/local/bin/buildifier
 
 # Install buildozer
-curl -o /usr/local/bin/buildozer-linux-$TARGETARCH -fsSL https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildozer-linux-$TARGETARCH \
+curl -o /usr/local/bin/buildozer-linux-$TARGETARCH -fsSL https://github.com/bazelbuild/buildtools/releases/download/v8.2.0/buildozer-linux-$TARGETARCH \
   && mv /usr/local/bin/buildozer-linux-$TARGETARCH /usr/local/bin/buildozer \
   && chmod +x /usr/local/bin/buildozer
 
 # Install Starlark larnguage server
-curl -o /usr/local/bin/starpls-linux-$TARGETARCH -fsSL https://github.com/withered-magic/starpls/releases/download/v0.1.12/starpls-linux-$TARGETARCH \
-  && mv /usr/local/bin/starpls-linux-$TARGETARCH /usr/local/bin/starpls \
-  && chmod +x /usr/local/bin/starpls
-
+if [ "$(uname -m)" == "x86_64" ]; then
+  curl -o /usr/local/bin/starpls-linux-amd64 -fsSL https://github.com/withered-magic/starpls/releases/download/v0.1.21/starpls-linux-amd64 \
+    && mv /usr/local/bin/starpls-linux-amd64 /usr/local/bin/starpls \
+    && chmod +x /usr/local/bin/starpls
+else
+  curl -o /usr/local/bin/starpls-linux-aarch64 -fsSL https://github.com/withered-magic/starpls/releases/download/v0.1.15/starpls-linux-aarch64 \
+    && mv /usr/local/bin/starpls-linux-aarch64 /usr/local/bin/starpls \
+    && chmod +x /usr/local/bin/starpls
+fi

--- a/dotnet/private/tests/dependency_resolution/targeting_pack_nuget_conflict/BUILD.bazel
+++ b/dotnet/private/tests/dependency_resolution/targeting_pack_nuget_conflict/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":tests.bzl", "tests")
+
+tests()

--- a/dotnet/private/tests/dependency_resolution/targeting_pack_nuget_conflict/Main.cs
+++ b/dotnet/private/tests/dependency_resolution/targeting_pack_nuget_conflict/Main.cs
@@ -1,0 +1,29 @@
+namespace TargetingPackNugetConflict
+{
+    using System;
+    using System.Text.Json;
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var outputFile = args[0];
+            if (string.IsNullOrEmpty(outputFile))
+            {
+                throw new ArgumentException("Output file path must be provided as the first argument.");
+            }
+            // We use the System.Text.Json dll for the test. The version of the user provided
+            // System.Text.Json is 7.0.3 while the targeting pack has the latest version.
+            // We publish a self-contained app targeting: 
+            // * net8.0 (higher than user provided version),
+            // * net7.0 (Same as user provided version),
+            // * net6.0 (lower than user provided version). 
+            // We write the version of the System.Text.Json assembly to the output file in args[0]
+            var systemTextJsonAssembly = typeof(System.Text.Json.JsonSerializer).Assembly;
+            using (var writer = new System.IO.StreamWriter(outputFile))
+            {
+                writer.WriteLine($"{systemTextJsonAssembly.GetName().Version}");
+            }
+        }
+    }
+}

--- a/dotnet/private/tests/dependency_resolution/targeting_pack_nuget_conflict/README.md
+++ b/dotnet/private/tests/dependency_resolution/targeting_pack_nuget_conflict/README.md
@@ -1,0 +1,9 @@
+# Targeting pack confligt with NuGet package
+
+This test checks that DLLs provided by a targeting pack that conflict with DLLs in a user provided by a NuGet package
+are resolved correctly. The rules are:
+
+* If the targeting pack version is higher or equal to the NuGet package version, the targeting pack DLL is used.
+* If the NuGet package version is higher than the targeting pack version, the NuGet package DLL is used.
+
+We also need to make sure that the behaviour is the same in both a the `csharp_binary/fsharp_binary` rules and the `publish_binary`.

--- a/dotnet/private/tests/dependency_resolution/targeting_pack_nuget_conflict/targeting_pack_nuget_conflict.csproj
+++ b/dotnet/private/tests/dependency_resolution/targeting_pack_nuget_conflict/targeting_pack_nuget_conflict.csproj
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Main.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
+  </ItemGroup>
+</Project>

--- a/dotnet/private/tests/dependency_resolution/targeting_pack_nuget_conflict/tests.bzl
+++ b/dotnet/private/tests/dependency_resolution/targeting_pack_nuget_conflict/tests.bzl
@@ -1,0 +1,45 @@
+load("@aspect_bazel_lib//lib:run_binary.bzl", "run_binary")
+load("@aspect_bazel_lib//lib:testing.bzl", "assert_contains")
+load(
+    "//dotnet:defs.bzl",
+    "csharp_binary",
+    "publish_binary",
+)
+
+EXPECTED_VERSION_PER_TFM = {
+    "net6.0": "7.0.0.0",
+    "net7.0": "7.0.0.0",
+    "net8.0": "8.0.0.0",
+}
+
+def tests():
+    """Returns a list of test targets."""
+    for tfm, expected_version in EXPECTED_VERSION_PER_TFM.items():
+        csharp_binary(
+            name = "{tfm}".format(tfm = tfm),
+            srcs = ["Main.cs"],
+            target_frameworks = ["{tfm}".format(tfm = tfm)],
+            deps = [
+                "@paket.rules_dotnet_dev_nuget_packages//system.text.json",
+            ],
+        )
+
+        publish_binary(
+            name = "publish_{tfm}".format(tfm = tfm),
+            binary = ":{tfm}".format(tfm = tfm),
+            self_contained = True,
+            target_framework = "{tfm}".format(tfm = tfm),
+        )
+
+        run_binary(
+            name = "run_{tfm}".format(tfm = tfm),
+            outs = ["version_{tfm}".format(tfm = tfm)],
+            args = ["$@"],
+            tool = ":publish_{tfm}".format(tfm = tfm),
+        )
+
+        assert_contains(
+            name = "assert_{tfm}".format(tfm = tfm),
+            actual = ":run_{tfm}".format(tfm = tfm),
+            expected = expected_version,
+        )

--- a/dotnet/private/tests/dependency_resolution/targeting_pack_nuget_conflict/tests.bzl
+++ b/dotnet/private/tests/dependency_resolution/targeting_pack_nuget_conflict/tests.bzl
@@ -1,3 +1,5 @@
+"Tests for targeting pack conflicts with user provided dependencies."
+
 load("@aspect_bazel_lib//lib:run_binary.bzl", "run_binary")
 load("@aspect_bazel_lib//lib:testing.bzl", "assert_contains")
 load(


### PR DESCRIPTION
## What?
Take care of conflicts between user provided deps and targeting/runtime pack provided DLLs.

## How?
* Update the logic that generates the deps.json file to omit the files that are overridden
* Update the publish_binary to read the deps.json to decide if a file should be copied

This behaviour imitates the behaviour that MSBuild has.