### PR TITLE
Fix remote execution for web sdk (Issue #501)

### DIFF
--- a/dotnet/repositories.bzl
+++ b/dotnet/repositories.bzl
@@ -45,6 +45,7 @@ filegroup(
     data = glob([
         "host/**/*",
         "sdk/**/*",
+        "shared/Microsoft.AspNetCore.App/**/*",
         "shared/Microsoft.NETCore.App/**/*",
     ]),
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Copy over the AspNetCore dependencies, which is needed for remote execution for runnables that require the web sdk instead of default.