### PR TITLE
Update paket2bazel README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ primer on Bazel.
 See API documentation at https://registry.bazel.build/docs/rules_dotnet
 
 See examples in the [examples](examples/) folder.
+
+## Dependencies
+
+See `tools/paket2bazel` for instructions of how to include and use external dependencies.

--- a/tools/paket2bazel/README.md
+++ b/tools/paket2bazel/README.md
@@ -26,6 +26,8 @@ After generating the `paket.lock` file, you can then generate the required Bazel
 bazel run @rules_dotnet//tools/paket2bazel -- --dependencies-file $(pwd)/paket.dependencies  --output-folder $(pwd)/deps
 ```
 
+Add an empty `BUILD` file to `($pwd)` so that Bazel recognizes the folder as part of its domain.
+
 Now there should be a `paket.bzl` and `paket.extensions.bzl` in the root folder. This may also appear as `paket.main.bzl` and `paket.main_extensions.bzl` where each group is labeled in the same pattern.
 
 In your `MODULE.bazel` file, the following exposes the dependencies for consumption in BUILD files:

--- a/tools/paket2bazel/README.md
+++ b/tools/paket2bazel/README.md
@@ -5,7 +5,36 @@
 Paket fits well with Bazel because it generates a `paket.lock` file that can be used
 to deterministically generate Bazel targets for NuGet packages.
 
-## How to use
+## Bazel MODULE
+
+The first steps are creating a `paket.dependencies` file to then use `paket` to generate a `paket.lock` file. Both are required to generate a local Bazel extension for use in `MODULE.bazel`.
+
+To generate the `paket.lock` file, these steps work on Linux systems:
+- `curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh`
+- `chmod +x dotnet-install.sh`
+- `./dotnet-install.sh --version [#.#.###]`
+- `export DOTNET_ROOT=$HOME/.dotnet`
+- `export PATH=$PATH:$HOME/.dotnet`
+- `dotnet new tool-manifest`
+- `dotnet tool install paket`
+- `dotnet paket install`
+
+NOTE: This expects the `paket.dependencies` file to live in the root folder.
+
+After generating the `paket.lock` file, you can then generate the required Bazel extension with:
+```sh
+bazel run @rules_dotnet//tools/paket2bazel -- --dependencies-file $(pwd)/paket.dependencies  --output-folder $(pwd)/deps
+```
+
+Now there should be a `paket.bzl` and `paket.extensions.bzl` in the root folder. This may also appear as `paket.main.bzl` and `paket.main_extensions.bzl` where each group is labeled in the same pattern.
+
+In your `MODULE.bazel` file, the following exposes the dependencies for consumption in BUILD files:
+```starlark
+main_extension = use_extension("//deps:paket.main_extension.bzl", "main_extension")
+use_repo(main_extension, "paket.main")
+```
+
+## Bazel WORKSPACES (Legacy, Bazel <8.0.0)
 
 First you need to set up your paket.dependencies and paket.lock file. See the [Paket docs](https://fsprojects.github.io/Paket/) on how to get started with Paket.
 


### PR DESCRIPTION
Add Bazel MODULE instructions. Point new users explicitly to `paket2bazel` for external dependency management.

This took 8+ hours to backwards engineer. To be fair, I do not develop with C#, so the nuances were lost on me for many steps. The changes here are targeting folks new to the ecosystem with explicit instructions vs. having to dig into the repo.

The update should hopefully trigger search assistants such as Google AI, DuckDuckGo AI, and local models to give correct feedback on issues.