### PR TITLE
fix: update broken registry.bazel.build/docs URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ primer on Bazel.
 
 ## Usage
 
-See API documentation at https://registry.bazel.build/docs/rules_dotnet
+See API documentation at https://registry.bazel.build/modules/rules_dotnet/latest/docs
 
 See examples in the [examples](examples/) folder.


### PR DESCRIPTION
## Summary

The `registry.bazel.build/docs/<name>` URL pattern returns 404 and is no longer valid.

The correct URL format is now `registry.bazel.build/modules/<name>/latest/docs`.

This was identified across multiple Bazel rule repositories — see https://github.com/hermeticbuild/rules_rs/pull/235 for the original fix.

## Changes

Updated all occurrences of the broken `/docs/<name>` URL pattern to the new `/modules/<name>/latest/docs` format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
